### PR TITLE
Feature/#3-custom-exception-settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@
 .idea/**/usage.statistics.xml
 .idea/**/dictionaries
 .idea/**/shelf
-
+*.properties
 settings.gradle
 gradle/wrapper
 gradlew

--- a/src/main/java/f4/email/config/AwsConfig.java
+++ b/src/main/java/f4/email/config/AwsConfig.java
@@ -5,6 +5,7 @@ import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.services.simpleemail.AmazonSimpleEmailService;
 import com.amazonaws.services.simpleemail.AmazonSimpleEmailServiceClient;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
@@ -18,6 +19,7 @@ public class AwsConfig {
   @Value("${aws.region}")
   private String region;
 
+  @Bean
   public AmazonSimpleEmailService amazonSimpleEmailService() {
     return AmazonSimpleEmailServiceClient.builder()
         .withRegion(region)

--- a/src/main/java/f4/email/constant/CustomErrorCode.java
+++ b/src/main/java/f4/email/constant/CustomErrorCode.java
@@ -1,0 +1,14 @@
+package f4.email.constant;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum CustomErrorCode {
+  EMAIL_TEMPLATE_LOADING_FAILED(401, "이메일 템플릿을 불러오는데 실패했습니다."),
+  EMAIL_SENDING_FAILED(402, "이메일 전송에 실패했습니다.");
+
+  private final int code;
+  private final String message;
+}

--- a/src/main/java/f4/email/exception/CustomException.java
+++ b/src/main/java/f4/email/exception/CustomException.java
@@ -1,0 +1,18 @@
+package f4.email.exception;
+
+import f4.email.constant.CustomErrorCode;
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+  private final CustomErrorCode customErrorCode;
+
+  public CustomException(CustomErrorCode customErrorCode) {
+    super(customErrorCode.getMessage());
+    this.customErrorCode = customErrorCode;
+  }
+  public CustomException(CustomErrorCode customErrorCode, Throwable cause) {
+    super(customErrorCode.getMessage(), cause);
+    this.customErrorCode = customErrorCode;
+  }
+}

--- a/src/main/java/f4/email/exception/ErrorDetails.java
+++ b/src/main/java/f4/email/exception/ErrorDetails.java
@@ -1,0 +1,17 @@
+package f4.email.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ErrorDetails {
+    private LocalDateTime timestamp;
+    private int code;
+    private String path;
+    private String message;
+}

--- a/src/main/java/f4/email/exception/GlobalExceptionHandler.java
+++ b/src/main/java/f4/email/exception/GlobalExceptionHandler.java
@@ -1,0 +1,23 @@
+package f4.email.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.time.LocalDateTime;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+  @ExceptionHandler({CustomException.class})
+  public ResponseEntity<ErrorDetails> customExceptionHandler(CustomException e) {
+    return new ResponseEntity<>(
+        ErrorDetails.builder()
+            .timestamp(LocalDateTime.now())
+            .code(e.getCustomErrorCode().getCode())
+            .message(e.getCustomErrorCode().getMessage())
+            .build(),
+        HttpStatus.BAD_REQUEST);
+  }
+}


### PR DESCRIPTION
* CustomErrorCode
-- 401 -> "이메일 템플릿을 불러오는데 실패했습니다."
-- 402 -> "이메일 전송에 실패했습니다."
enum을 사용해 에러코드를 작성해주었음.
우선 예상 가능한 에러코드만 먼저 작성함.

* CustomException
-- RuntimeException을 상속받는 CustomException코드를 작성함.
ErrorCode만 생성받는 것과 에러 메세지까지 상속받는 두가지 생성자를 작성하였음.

* ErrorDetails
-- 에러 발생시간과, 에러코드, 경로, 메세지를 생성하는 dto

* GlobalExceptionHandler
-- 발생하는 Exception들을 CustomException으로 변환하는 핸들러 코드를 작성하였음.

+
AwsConfig클래스에서 빠트린 Bean 어노테이션을 작성해주었다.
추가로 AWS 관련 액세스키와 시크릿키를 properties 파일에 작성해주었고, gitIgnore에도 추가하였다.